### PR TITLE
Support for custom delegate-based events and fix for indentation in generated stubs

### DIFF
--- a/src/SimpleStubs.CodeGen/Utils/StubbingUtils.cs
+++ b/src/SimpleStubs.CodeGen/Utils/StubbingUtils.cs
@@ -1,11 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Etg.SimpleStubs.CodeGen.Utils
 {

--- a/test/TestClassLibrary/ITestInterface.cs
+++ b/test/TestClassLibrary/ITestInterface.cs
@@ -113,4 +113,11 @@ namespace TestClassLibrary
 
         void SetBoo<T, A>(T t, A a) where T : class, IDisposable, new() where A : new();
     }
+
+    public delegate void CustomDelegateBasedHandler(int arg1, string arg2, object arg3);
+
+    public interface ICustomDelegateBasedEventExample
+    {
+        event CustomDelegateBasedHandler CustomDelegateEventOccurred;
+    }
 }

--- a/test/TestClassLibraryTest/EventStubsTest.cs
+++ b/test/TestClassLibraryTest/EventStubsTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestClassLibrary;
 
 namespace TestClassLibraryTest
@@ -16,11 +17,32 @@ namespace TestClassLibraryTest
             {
                 sender = s;
                 newNumber = num;
-            }
-                ;
+            };
+
             stub.PhoneNumberChanged_Raise(this, 55);
             Assert.AreEqual(55, newNumber);
             Assert.AreEqual(this, sender);
+        }
+
+        [TestMethod]
+        public void TestCustomDelegateBasedEventStub()
+        {
+            int arg1 = 0;
+            string arg2 = null;
+            object arg3 = null;
+            var stub = new StubICustomDelegateBasedEventExample();
+            stub.CustomDelegateEventOccurred += (i, s, o) =>
+            {
+                arg1 = i;
+                arg2 = s;
+                arg3 = o;
+            };
+
+            stub.CustomDelegateEventOccurred_Raise(55, "test", new Random(1));
+
+            Assert.AreEqual(55, arg1);
+            Assert.AreEqual("test", arg2);
+            Assert.AreEqual(typeof(Random), arg3.GetType());
         }
     }
 }


### PR DESCRIPTION
I never got to the bottom of why the parsed if/else blocks seemed to get ignored by the Formatter, but it does a much better job of indentation when they're added via ```SyntaxFactory.IfStatement(...)```.