### PR TITLE
Fix for 'using static'

### DIFF
--- a/src/SimpleStubs.CodeGen/CodeGen/ProjectStubber.cs
+++ b/src/SimpleStubs.CodeGen/CodeGen/ProjectStubber.cs
@@ -55,10 +55,28 @@ namespace Etg.SimpleStubs.CodeGen.CodeGen
                         Trace.TraceError($"Could not generate stubs for interface {interfaceDclr}, Exception: {e}");
                     }
 				}
-				usings.AddRange(syntaxTree.GetCompilationUnitRoot().Usings.Where(@using => !@using.ChildTokens().Any(@token => token.IsKind(SyntaxKind.StaticKeyword))).Select(@using => @using.Name.ToString()));
+				CopyUsings(syntaxTree, usings);
 			}
 
             return new StubProjectResult(cu, usings);
+        }
+
+        private static void CopyUsings(SyntaxTree syntaxTree, List<string> usings)
+        {
+            foreach (UsingDirectiveSyntax usingDirectiveSyntax in syntaxTree.GetCompilationUnitRoot().Usings)
+            {
+                string usingName = usingDirectiveSyntax.Name.ToString();
+                if (IsStaticUsing(usingDirectiveSyntax))
+                {
+                    usingName = $"static {usingName}";
+                }
+                usings.Add(usingName);
+            }
+        }
+
+        private static bool IsStaticUsing(UsingDirectiveSyntax usingDirectiveSyntax)
+        {
+            return usingDirectiveSyntax.ChildTokens().Any(token => token.IsKind(SyntaxKind.StaticKeyword));
         }
 
         private bool SatisfiesVisibilityConstraints(InterfaceDeclarationSyntax i)

--- a/src/SimpleStubs.CodeGen/CodeGen/ProjectStubber.cs
+++ b/src/SimpleStubs.CodeGen/CodeGen/ProjectStubber.cs
@@ -54,9 +54,9 @@ namespace Etg.SimpleStubs.CodeGen.CodeGen
                     {
                         Trace.TraceError($"Could not generate stubs for interface {interfaceDclr}, Exception: {e}");
                     }
-                }
-                usings.AddRange(syntaxTree.GetCompilationUnitRoot().Usings.Select(@using => @using.Name.ToString()));
-            }
+				}
+				usings.AddRange(syntaxTree.GetCompilationUnitRoot().Usings.Where(@using => !@using.ChildTokens().Any(@token => token.IsKind(SyntaxKind.StaticKeyword))).Select(@using => @using.Name.ToString()));
+			}
 
             return new StubProjectResult(cu, usings);
         }

--- a/test/TestClassLibrary/ITestInterface.cs
+++ b/test/TestClassLibrary/ITestInterface.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
+// used to test that static usings are handled correctly.
+using static System.String;
+
 namespace TestClassLibrary
 {
     public interface IAppConfigPeriodicRefreshHandler : IDisposable


### PR DESCRIPTION
SimpleStubs.generated.cs should not include usings which were 'using static' from origin. Therefore we're filtering these out.
If a file contains for example `using static System.String`, the Code Generator converted it to `using System.String` which is wrong.