### PR TITLE
Added example for generic interface in ignored interfaces.

### DIFF
--- a/Documentation/Tutorial.md
+++ b/Documentation/Tutorial.md
@@ -189,7 +189,8 @@ SimpleStubs also supports an optional configuration file that can be added to th
     ],
     "IgnoredInterfaces": [
         "MyNamespace.IFooInterface",
-        "MyNamespace.IBarInterface"
+        "MyNamespace.IBarInterface",
+        "MyNamespace.IGenericInterface<TK, TV>"
     ],
     "StubInternalInterfaces": false,
     "StubCurrentProject": false,


### PR DESCRIPTION
It's tricky to know how to add generic interfaces to the ignored list of stubs.
As a developer might wonder whether it's IGenericInterface<,> or IGenericInterface`2 etc...

The correct way is to use the literal definition used while defining the interface.

```
public interface IGenericInterface<TK, TV>
{
....
}
```

will be ignored using `"MyNamespace.IGenericInterface<TK, TV>"`