### PR TITLE
Added support for custom event delegates that have a return type.

### DIFF
--- a/test/TestClassLibrary/ITestInterface.cs
+++ b/test/TestClassLibrary/ITestInterface.cs
@@ -84,7 +84,7 @@ namespace TestClassLibrary
 
         void SetGenericValue<T>(T value);
     }
-
+    
     public interface IIgnoredInterface : IDisposable
     {
     }
@@ -126,10 +126,15 @@ namespace TestClassLibrary
     }
 
     public delegate void CustomDelegateBasedHandler(int arg1, string arg2, object arg3);
+    public delegate string CustomDelegateBasedHandlerWithReturnType(object sender, EventArgs eventArgs);
+    public delegate string CustomDelegateBasedHandlerWithReturnType<T>(T eventArgs);
 
     public interface ICustomDelegateBasedEventExample
     {
         event CustomDelegateBasedHandler CustomDelegateEventOccurred;
+
+        event CustomDelegateBasedHandlerWithReturnType CustomDelegateWithReturnTypeEventOccurred;
+        event CustomDelegateBasedHandlerWithReturnType<string> CustomDelegateWithReturnTypeWithParameterEventOccurred;
     }
 }
 

--- a/test/TestClassLibraryTest/EventStubsTest.cs
+++ b/test/TestClassLibraryTest/EventStubsTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestClassLibrary;
 
@@ -43,6 +45,38 @@ namespace TestClassLibraryTest
             Assert.AreEqual(55, arg1);
             Assert.AreEqual("test", arg2);
             Assert.AreEqual(typeof(Random), arg3.GetType());
+        }
+
+        [TestMethod]
+        public void TestCustomDelegateBasedWithReturnTypeEventStub()
+        {
+            var stub = new StubICustomDelegateBasedEventExample();
+            stub.CustomDelegateWithReturnTypeEventOccurred += (sender, args) => "Teststring1";
+            stub.CustomDelegateWithReturnTypeEventOccurred += (sender, args) => "Teststring2";
+            stub.CustomDelegateWithReturnTypeEventOccurred += (sender, args) => "Teststring3";
+
+            var receivedList = stub.CustomDelegateWithReturnTypeEventOccurred_Raise(stub, EventArgs.Empty).ToList();
+
+            Assert.AreEqual(receivedList.Count, 3);
+            Assert.AreEqual(receivedList[0], "Teststring1");
+            Assert.AreEqual(receivedList[1], "Teststring2");
+            Assert.AreEqual(receivedList[2], "Teststring3");
+        }
+
+        [TestMethod]
+        public void TestCustomDelegateBasedWithReturnTypeWithParameterEventStub()
+        {
+            var stub = new StubICustomDelegateBasedEventExample();
+            stub.CustomDelegateWithReturnTypeWithParameterEventOccurred += args => args + "Teststring1";
+            stub.CustomDelegateWithReturnTypeWithParameterEventOccurred += args => args + "Teststring2";
+            stub.CustomDelegateWithReturnTypeWithParameterEventOccurred += args => args + "Teststring3";
+
+            var receivedList = stub.CustomDelegateWithReturnTypeWithParameterEventOccurred_Raise("My").ToList();
+
+            Assert.AreEqual(receivedList.Count, 3);
+            Assert.AreEqual(receivedList[0], "MyTeststring1");
+            Assert.AreEqual(receivedList[1], "MyTeststring2");
+            Assert.AreEqual(receivedList[2], "MyTeststring3");
         }
     }
 }


### PR DESCRIPTION
The PullRequest added the possability to use custom event delegates with return types. The return values of all subscribers are returned from the raise method as `IEnumerable<T>`.
This allows to have a special `AsyncEventHandler` as described here: https://github.com/Microsoft/SimpleStubs/issues/35
